### PR TITLE
Adding Limit Tags Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ with `AWS_ECR_EXPORTER`.
 | `AWS_ECR_EXPORTER_RATE_LIMIT_BURSTS`         | The maximum burst size of the rate limiter.                                            | `1`           | N/A                                       |
 | `AWS_ECR_EXPORTER_RATE_LIMIT_FREQUENCY`      | The maximum overall event rate limit in Hz.                                            | `2`           | N/A                                       |
 | `AWS_ECR_EXPORTER_LIMITS_IMAGE_TAGS_COUNT`   | The maximum number of image tags the exporter will collect metrics for per repository. | `3`           | N/A                                       |
-| `AWS_ECR_EXPORTER_LIMITS_IMAGE_TAGS_ENABLED` | Whether or not the image tags limit is enabled.                                        | `true`        | `true`, `false`                           |
+| `AWS_ECR_EXPORTER_LIMITS_IMAGE_TAGS_ENABLED` | Whether or not the image tags limit is enabled.                                        | `false`       | `true`, `false`                           |
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ defaults. Below is a table of all configurable element, their default values, an
 descriptions. All configurable elements can be set via environment variables when prefixed
 with `AWS_ECR_EXPORTER`.
 
-| Element                                 | Description                                                  | Default       | Values                                    |
-| --------------------------------------- | ------------------------------------------------------------ | ------------- | ----------------------------------------- |
-| `AWS_ECR_EXPORTER_CRON_SCHEDULE`        | The cron schedule that triggers the updating of the metrics. | `0 0 * * * *` | N/A                                       |
-| `AWS_ECR_EXPORTER_LOG_FORMAT`           | The output format of the logs of the exporter.               | `logfmt`      | `json`, `logfmt`, `text`                  |
-| `AWS_ECR_EXPORTER_LOG_LEVEL`            | The verbosity level of the logs of the exporter.             | `info`        | `debug`, `info`, `warn`, `error`, `fatal` |
-| `AWS_ECR_EXPORTER_WEB_HOST`             | The address/host the webserver will bind against.            | `0.0.0.0`     | N/A                                       |
-| `AWS_ECR_EXPORTER_WEB_PORT`             | The port the webserver will bind against.                    | `9090`        | N/A                                       |
-| `AWS_ECR_EXPORTER_WEB_METRICS_PATH`     | The path the metrics will be exposed on.                     | `/metrics`    | N/A                                       |
-| `AWS_ECR_EXPORTER_RATE_LIMIT_BURSTS`    | The maximum burst size of the rate limiter.                  | `1`           | N/A                                       |
-| `AWS_ECR_EXPORTER_RATE_LIMIT_FREQUENCY` | The maximum overall event rate limit in Hz.                  | `2`           | N/A                                       |
+| Element                                      | Description                                                                            | Default       | Values                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------- | ------------- | ----------------------------------------- |
+| `AWS_ECR_EXPORTER_CRON_SCHEDULE`             | The cron schedule that triggers the updating of the metrics.                           | `0 0 * * * *` | N/A                                       |
+| `AWS_ECR_EXPORTER_LOG_FORMAT`                | The output format of the logs of the exporter.                                         | `logfmt`      | `json`, `logfmt`, `text`                  |
+| `AWS_ECR_EXPORTER_LOG_LEVEL`                 | The verbosity level of the logs of the exporter.                                       | `info`        | `debug`, `info`, `warn`, `error`, `fatal` |
+| `AWS_ECR_EXPORTER_WEB_HOST`                  | The address/host the webserver will bind against.                                      | `0.0.0.0`     | N/A                                       |
+| `AWS_ECR_EXPORTER_WEB_PORT`                  | The port the webserver will bind against.                                              | `9090`        | N/A                                       |
+| `AWS_ECR_EXPORTER_WEB_METRICS_PATH`          | The path the metrics will be exposed on.                                               | `/metrics`    | N/A                                       |
+| `AWS_ECR_EXPORTER_RATE_LIMIT_BURSTS`         | The maximum burst size of the rate limiter.                                            | `1`           | N/A                                       |
+| `AWS_ECR_EXPORTER_RATE_LIMIT_FREQUENCY`      | The maximum overall event rate limit in Hz.                                            | `2`           | N/A                                       |
+| `AWS_ECR_EXPORTER_LIMITS_IMAGE_TAGS_COUNT`   | The maximum number of image tags the exporter will collect metrics for per repository. | `3`           | N/A                                       |
+| `AWS_ECR_EXPORTER_LIMITS_IMAGE_TAGS_ENABLED` | Whether or not the image tags limit is enabled.                                        | `true`        | `true`, `false`                           |
 
 ## Metrics
 

--- a/main.go
+++ b/main.go
@@ -18,13 +18,19 @@ type AwsEcrClientKey struct{}
 var rateLimiter rate.Limiter
 
 func main() {
-	// Setup our configuration.
+	// Setup our logging configuration.
 	viper.SetDefault("log.format", "logfmt")
 	viper.SetDefault("log.level", "info")
+
+	// Setup the web server configuration.
 	viper.SetDefault("web.host", "0.0.0.0")
 	viper.SetDefault("web.port", 9090)
 	viper.SetDefault("web.metrics.path", "/metrics")
+
+	// Setup our metrics collection configuration.
 	viper.SetDefault("cron.schedule", "0 0 * * * *")
+	viper.SetDefault("limits.image.tags.count", 3)
+	viper.SetDefault("limits.image.tags.enabled", true)
 
 	// Setup the rate limiter configuration.
 	viper.SetDefault("rate.limit.bursts", 1)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	// Setup our metrics collection configuration.
 	viper.SetDefault("cron.schedule", "0 0 * * * *")
 	viper.SetDefault("limits.image.tags.count", 3)
-	viper.SetDefault("limits.image.tags.enabled", true)
+	viper.SetDefault("limits.image.tags.enabled", false)
 
 	// Setup the rate limiter configuration.
 	viper.SetDefault("rate.limit.bursts", 1)


### PR DESCRIPTION
Adds in a feature to limit the number of image tags the exporter will call the AWS API for populating metrics. These calls can quickly empty the rate limiter's bucket and cause issues.

~By default the image tag limit is enabled and is set to only populate metrics for the latest three images pushed to the repository.~

Decided to change the image tag limiter to default to disabled to keep the behavior consistent with previous releases.